### PR TITLE
Add tracking for mtime/file hashes in metadata file

### DIFF
--- a/src/baseTypes.ts
+++ b/src/baseTypes.ts
@@ -94,6 +94,8 @@ export interface RemotelySavePluginSettings {
   trashLocal: boolean;
   syncTrash: boolean;
   syncBookmarks: boolean;
+  checkFileHashes: boolean;
+
 
   /**
    * @deprecated

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,7 @@ const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   trashLocal: false,
   syncTrash: false,
   syncBookmarks: true,
+  checkFileHashes: false
 };
 
 interface OAuth2Info {
@@ -396,9 +397,7 @@ export default class RemotelySavePlugin extends Plugin {
       client.serviceType,
       triggerSource,
       this.app.vault,
-      this.settings.syncConfigDir,
-      this.settings.syncTrash,
-      this.settings.syncBookmarks,
+      this.settings,
       this.app.vault.configDir,
       this.settings.syncUnderscoreItems,
       this.settings.skipSizeLargerThan,

--- a/src/main.ts
+++ b/src/main.ts
@@ -391,7 +391,7 @@ export default class RemotelySavePlugin extends Plugin {
       remoteStates,
       local,
       localConfigDirContents,
-      origMetadataOnRemote.deletions,
+      origMetadataOnRemote,
       localHistory,
       client.serviceType,
       triggerSource,

--- a/src/metadataOnRemote.ts
+++ b/src/metadataOnRemote.ts
@@ -25,23 +25,34 @@ export interface DeletionOnRemote {
   actionWhen: number;
 }
 
+export interface FileOnRemote {
+  key: string;
+  mtime: number;
+  hash: string;
+}
+
 export interface MetadataOnRemote {
   version?: string;
   generatedWhen?: number;
   deletions?: DeletionOnRemote[];
+  filesOnRemote?: FileOnRemote[];
 }
 
 export const isEqualMetadataOnRemote = (
   a: MetadataOnRemote,
   b: MetadataOnRemote
 ) => {
-  const m1 = a === undefined ? { deletions: [] } : a;
-  const m2 = b === undefined ? { deletions: [] } : b;
+  const m1 = a === undefined ? { deletions: [], filesOnRemote: [] } : a;
+  const m2 = b === undefined ? { deletions: [], filesOnRemote: [] } : b;
 
   // we only need to compare deletions
   const d1 = m1.deletions === undefined ? [] : m1.deletions;
   const d2 = m2.deletions === undefined ? [] : m2.deletions;
-  return isEqual(d1, d2);
+
+  // Compare files on remote.
+  const f1 = m1.filesOnRemote == undefined ? [] : m1.filesOnRemote;
+  const f2 = m2.filesOnRemote == undefined ? [] : m1.filesOnRemote;
+  return isEqual(d1, d2) && isEqual(f1, f2);
 };
 
 export const serializeMetadataOnRemote = (x: MetadataOnRemote) => {
@@ -55,6 +66,9 @@ export const serializeMetadataOnRemote = (x: MetadataOnRemote) => {
   }
   if (y["deletions"] === undefined) {
     y["deletions"] = [];
+  }
+  if (y["filesOnRemote"] === undefined) {
+    y["filesOnRemote"] = [];
   }
 
   const z = {

--- a/src/metadataOnRemote.ts
+++ b/src/metadataOnRemote.ts
@@ -56,21 +56,6 @@ export const isEqualMetadataOnRemote = (
 };
 
 export const serializeMetadataOnRemote = (x: MetadataOnRemote) => {
-  const y = x;
-
-  if (y["version"] === undefined) {
-    y["version"] === DEFAULT_VERSION_FOR_METADATAONREMOTE;
-  }
-  if (y["generatedWhen"] === undefined) {
-    y["generatedWhen"] = Date.now();
-  }
-  if (y["deletions"] === undefined) {
-    y["deletions"] = [];
-  }
-  if (y["filesOnRemote"] === undefined) {
-    y["filesOnRemote"] = [];
-  }
-
   const z = {
     readme: DEFAULT_README_FOR_METADATAONREMOTE,
     d: reverseString(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1774,6 +1774,22 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
       });
 
     new Setting(advDiv)
+      .setName(t("settings_sync_hash_files"))
+      .setDesc(t("settings_sync_hash_files_desc"))
+      .addDropdown((dropdown) => {
+        dropdown.addOption("disable", t("disable"));
+        dropdown.addOption("enable", t("enable"));
+        dropdown
+          .setValue(
+            `${this.plugin.settings.syncCheckFileHashes ? "enable" : "disable"}`
+          )
+          .onChange(async (val) => {
+            this.plugin.settings.syncCheckFileHashes = val === "enable";
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(advDiv)
       .setName(t("settings_configdir"))
       .setDesc(
         t("settings_configdir_desc", {
@@ -2021,6 +2037,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
             this.app.vault,
             undefined,
             undefined,
+            [],
             [],
             this.plugin.settings.password );
           new Notice(t("settings_reset_sync_metadata_notice"));

--- a/tests/configPersist.test.ts
+++ b/tests/configPersist.test.ts
@@ -25,7 +25,8 @@ const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   enableStatusBarInfo: true,
   trashLocal: false,
   syncTrash: false,
-  syncBookmarks: true
+  syncBookmarks: true,
+  checkFileHashes: false
 };
 
 describe("Config Persist tests", () => {


### PR DESCRIPTION
Will fix #70 and #40.

TODO:

~~- Add setting to enable feature file hashing comparison~~
- Compute hash locally on sync only under certain conditions (remote doesn't have file, remote has file that local doesn't, etc)
- Compare hashes when determining action for files
- Save hashes in remote metadata
- Add mtime in generic file
- Change mtime comparisons from platform-specific code to this
- Remove option to disable metadata sync in S3

Also a reminder to remove S3 cloud provider specific warnings in readme