### PR TITLE
Bug fixes for syncRun and Sync on Remote

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1111,9 +1111,8 @@ export default class RemotelySavePlugin extends Plugin {
 
       const metadataMtime = await this.getMetadataMtime();
 
-      log.debug("Remote Metadata: " + metadataMtime + " Last Synced: " + this.lastSynced);
-
       if (metadataMtime !== this.lastSynced) {
+        log.debug("Sync on Remote ran | Remote Metadata:", metadataMtime + ", Last Synced:", this.lastSynced);
         this.syncRun("auto");
       }
     }, this.settings.syncOnRemoteChangesAfterMilliseconds);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1111,7 +1111,7 @@ export default class RemotelySavePlugin extends Plugin {
 
       const metadataMtime = await this.getMetadataMtime();
 
-      console.log("Remote Metadata: " + metadataMtime + " Last Synced: " + this.lastSynced);
+      log.debug("Remote Metadata: " + metadataMtime + " Last Synced: " + this.lastSynced);
 
       if (metadataMtime !== this.lastSynced) {
         this.syncRun("auto");

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export default class RemotelySavePlugin extends Plugin {
   settings: RemotelySavePluginSettings;
   db: InternalDBs;
   syncStatus: SyncStatusType;
-  lastModified: number;
+  lastSynced: number;
   statusBarElement: HTMLSpanElement;
   oauth2Info: OAuth2Info;
   currSyncMsg?: string;
@@ -294,7 +294,7 @@ export default class RemotelySavePlugin extends Plugin {
       this.updateLastSyncTime();
       this.syncingStatusText = undefined;
 
-      this.lastModified = await this.getMetadataMtime();
+      this.lastSynced = await this.getMetadataMtime();
 
       this.syncStatus = "idle";
     } catch (error) {
@@ -1111,7 +1111,9 @@ export default class RemotelySavePlugin extends Plugin {
 
       const metadataMtime = await this.getMetadataMtime();
 
-      if (metadataMtime !== this.lastModified) {
+      console.log("Remote Metadata: " + metadataMtime + " Last Synced: " + this.lastSynced);
+
+      if (metadataMtime !== this.lastSynced) {
         this.syncRun("auto");
       }
     }, this.settings.syncOnRemoteChangesAfterMilliseconds);

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,27 +158,30 @@ export default class RemotelySavePlugin extends Plugin {
       }
     };
 
-    if (this.syncStatus !== "idle" && triggerSource == "manual") {
-      // here the notice is shown regardless of triggerSource
+    // Make sure two syncs can't run at the same time
+    if (this.syncStatus !== "idle") {
+      if (triggerSource == "manual") {
+        new Notice(
+          "1/" + t("syncrun_alreadyrunning", {
+            maxSteps: `${MAX_STEPS}`,
+            pluginName: this.manifest.name,
+            syncStatus: this.syncStatus,
+          })
+        );
 
-      new Notice(
-        "1/" + t("syncrun_alreadyrunning", {
-          maxSteps: `${MAX_STEPS}`,
-          pluginName: this.manifest.name,
-          syncStatus: this.syncStatus,
-        })
-      );
+        // If already running, report finished status as user tried to manually sync
+        this.isManual = true;
 
-      // If already running, report finished status as user tried to manually sync
-      this.isManual = true;
+        log.debug(this.manifest.name, " already running in stage: ", this.syncStatus);
 
-      log.debug(this.manifest.name, " already running in stage: ", this.syncStatus);
-
-      if (this.currSyncMsg !== undefined && this.currSyncMsg !== "") {
-        log.debug(this.currSyncMsg);
+        if (this.currSyncMsg !== undefined && this.currSyncMsg !== "") {
+          log.debug(this.currSyncMsg);
+        }  
       }
+      
       return;
     }
+
     let originLabel = this.getOriginLabel();
 
     try {
@@ -221,6 +224,7 @@ export default class RemotelySavePlugin extends Plugin {
         }), 3
       );
       this.syncStatus = "checking_password";
+      
       const passwordCheckResult = await isPasswordOk(
         remoteRsp.Contents,
         this.settings.password
@@ -1100,7 +1104,7 @@ export default class RemotelySavePlugin extends Plugin {
     }
 
     const interval = window.setInterval(async () => {
-      // Prevents it from running multiple setIntervals, this will only happen if the plugin doesn't unload properly
+      // Tries to prevent it from running multiple setIntervals
       if (this.syncStatus !== "idle" || this.syncOnRemoteIntervalID !== interval) {
         return;
       }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1380,66 +1380,63 @@ export const doActualSync = async (
 
       await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password);
     }
-
-    return; // shortcut return, avoid too many nests below
   }
 
-  const { folderCreationOps, deletionOps, uploadDownloads, realTotalCount } =
-    splitThreeSteps(syncPlan, sortedKeys);
-  const nested = [folderCreationOps, deletionOps, uploadDownloads];
-  const logTexts = [
-    `1. create all folders from shadowest to deepest, also check undefined decision`,
-    `2. delete files and folders from deepest to shadowest`,
-    `3. upload or download files in parallel, with the desired concurrency=${concurrency}`,
-  ];
+  if (concurrency !== 1) {
+    const { folderCreationOps, deletionOps, uploadDownloads, realTotalCount } =
+      splitThreeSteps(syncPlan, sortedKeys);
+    const nested = [folderCreationOps, deletionOps, uploadDownloads];
+    const logTexts = [
+      `1. create all folders from shadowest to deepest, also check undefined decision`,
+      `2. delete files and folders from deepest to shadowest`,
+      `3. upload or download files in parallel, with the desired concurrency=${concurrency}`,
+    ];
 
-  log.debug("folderCreationOps: ", folderCreationOps.length,
-  " deletionOps: ", deletionOps.length,
-  " uploadDownloads: ", uploadDownloads.length);
+    log.debug("folderCreationOps: ", folderCreationOps.length,
+    " deletionOps: ", deletionOps.length,
+    " uploadDownloads: ", uploadDownloads.length);
 
-  for (let i = 0; i < nested.length; ++i) {
-    log.debug(logTexts[i]);
+    for (let i = 0; i < nested.length; ++i) {
+      const operations: FileOrFolderMixedState[][] = nested[i];
 
-    const operations: FileOrFolderMixedState[][] = nested[i];
+      for (let j = 0; j < operations.length; ++j) {
+        const singleLevelOps: FileOrFolderMixedState[] | undefined = operations[j];
 
-    for (let j = 0; j < operations.length; ++j) {
-      const singleLevelOps: FileOrFolderMixedState[] | undefined =
-        operations[j];
+        if (singleLevelOps === undefined || singleLevelOps === null) {
+          continue;
+        }
 
-      if (singleLevelOps === undefined || singleLevelOps === null) {
-        continue;
-      }
+        const queue = new PQueue({ concurrency: concurrency, autoStart: true });
+        const potentialErrors: Error[] = [];
+        let tooManyErrors = false;
 
-      const queue = new PQueue({ concurrency: concurrency, autoStart: true });
-      const potentialErrors: Error[] = [];
-      let tooManyErrors = false;
+        for (let k = 0; k < singleLevelOps.length; ++k) {
+          const val: FileOrFolderMixedState = singleLevelOps[k];
+          const key = val.key;
 
-      for (let k = 0; k < singleLevelOps.length; ++k) {
-        const val: FileOrFolderMixedState = singleLevelOps[k];
-        const key = val.key;
+          const fn = async () => {
+            await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password);
+          };
 
-        const fn = async () => {
-          await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password);
-        };
+          queue.add(fn).catch((e) => {
+            const msg = `${key}: ${e.message}`;
+            potentialErrors.push(new Error(msg));
+            if (potentialErrors.length >= 3) {
+              tooManyErrors = true;
+              queue.pause();
+              queue.clear();
+            }
+          });
+        }
 
-        queue.add(fn).catch((e) => {
-          const msg = `${key}: ${e.message}`;
-          potentialErrors.push(new Error(msg));
-          if (potentialErrors.length >= 3) {
-            tooManyErrors = true;
-            queue.pause();
-            queue.clear();
+        let queueSize = queue.size + queue.pending;
+        queue.on('next', async () => {
+          if (callbackSyncProcess !== undefined) {
+            await callbackSyncProcess(queueSize - queue.pending, queueSize);
           }
         });
-      }
-
-      let queueSize = queue.size + queue.pending;
-      queue.on('next', async () => {
-        if (callbackSyncProcess !== undefined) {
-          await callbackSyncProcess(queueSize - queue.pending, queueSize);
-        }
-      });
-      await queue.onIdle();
+        
+        await queue.onIdle();
 
         if (potentialErrors.length > 0) {
           if (tooManyErrors) {
@@ -1449,17 +1446,20 @@ export const doActualSync = async (
           }
           throw new AggregateError(potentialErrors);
         }
-
-        log.debug(`start syncing extra data lastly`);
-        await uploadExtraMeta(
-          client,
-          vault,
-          metadataFile,
-          origMetadata,
-          deletions,
-          password
-        );
-        log.debug(`finish syncing extra data`);
       }
+    }
   }
+
+  log.debug(`start syncing extra data lastly`);
+
+  await uploadExtraMeta(
+    client,
+    vault,
+    metadataFile,
+    origMetadata,
+    deletions,
+    password
+  );
+
+  log.debug(`finish syncing extra data`);
 };

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1066,14 +1066,6 @@ export const uploadExtraMeta = async (
     deletions: deletions,
   };
 
-  // TODO: optimize and/or refactor this. Inefficient until user deletes a file
-  if (origMetadata && origMetadata.deletions.length > 0 && isEqualMetadataOnRemote(origMetadata, newMetadata)) {
-    log.debug(
-      "metadata are the same, no need to re-generate and re-upload it."
-    );
-    return;
-  }
-
   const resultText = serializeMetadataOnRemote(newMetadata);
 
   await client.uploadToRemote(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1354,8 +1354,6 @@ export const doActualSync = async (
   callbackSizesGoWrong?: any,
   callbackSyncProcess?: any
 ) => {
-  const mixedStates = syncPlan.mixedStates;
-
   if (sizesGoWrong.length > 0) {
     log.debug(`some sizes are larger than the threshold, abort and show hints`);
     callbackSizesGoWrong(sizesGoWrong);
@@ -1363,81 +1361,61 @@ export const doActualSync = async (
   }
 
   log.debug(`concurrency === ${concurrency}`);
-  if (concurrency === 1) {
-    // run everything in sequence
-    // good old way
-    for (let i = 0; i < sortedKeys.length; ++i) {
-      const key = sortedKeys[i];
-      const val = mixedStates[key];
 
-      await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password);
-    }
-  }
+  const { folderCreationOps, deletionOps, uploadDownloads, realTotalCount } =  splitThreeSteps(syncPlan, sortedKeys);
+  const nested = [folderCreationOps, deletionOps, uploadDownloads];
+  const logTexts = [
+    `1. create all folders from shadowest to deepest, also check undefined decision`,
+    `2. delete files and folders from deepest to shadowest`,
+    `3. upload or download files in parallel, with the desired concurrency=${concurrency}`,
+  ];
 
-  if (concurrency !== 1) {
-    const { folderCreationOps, deletionOps, uploadDownloads, realTotalCount } =
-      splitThreeSteps(syncPlan, sortedKeys);
-    const nested = [folderCreationOps, deletionOps, uploadDownloads];
-    const logTexts = [
-      `1. create all folders from shadowest to deepest, also check undefined decision`,
-      `2. delete files and folders from deepest to shadowest`,
-      `3. upload or download files in parallel, with the desired concurrency=${concurrency}`,
-    ];
+  log.debug("folderCreationOps: ", folderCreationOps.length,
+  " deletionOps: ", deletionOps.length,
+  " uploadDownloads: ", uploadDownloads.length);
 
-    log.debug("folderCreationOps: ", folderCreationOps.length,
-    " deletionOps: ", deletionOps.length,
-    " uploadDownloads: ", uploadDownloads.length);
+  // Sync files in order of folder creation, deletions and uploads/downloads
+  // Must be for of to stop rest of code running before promises resolve
+  for (const operation of nested) {
+    for (const singleLevelOps of operation) {
+      if (singleLevelOps === undefined || singleLevelOps === null) {
+        continue;
+      }
 
-    for (let i = 0; i < nested.length; ++i) {
-      const operations: FileOrFolderMixedState[][] = nested[i];
+      const queue = new PQueue({ concurrency: concurrency, autoStart: true });
+      const potentialErrors: Error[] = [];
 
-      for (let j = 0; j < operations.length; ++j) {
-        const singleLevelOps: FileOrFolderMixedState[] | undefined = operations[j];
+      for (let i = 0; i < singleLevelOps.length; ++i) {
+        const val: FileOrFolderMixedState = singleLevelOps[i];
+        const key = val.key;
 
-        if (singleLevelOps === undefined || singleLevelOps === null) {
-          continue;
-        }
+        const syncCall = queue.add(async () => await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password));
 
-        const queue = new PQueue({ concurrency: concurrency, autoStart: true });
-        const potentialErrors: Error[] = [];
-        let tooManyErrors = false;
+        syncCall.catch((error) => {
+          const message = `${key}: ${error.message}`;
+          potentialErrors.push(new Error(message));
 
-        for (let k = 0; k < singleLevelOps.length; ++k) {
-          const val: FileOrFolderMixedState = singleLevelOps[k];
-          const key = val.key;
-
-          const fn = async () => {
-            await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password);
-          };
-
-          queue.add(fn).catch((e) => {
-            const msg = `${key}: ${e.message}`;
-            potentialErrors.push(new Error(msg));
-            if (potentialErrors.length >= 3) {
-              tooManyErrors = true;
-              queue.pause();
-              queue.clear();
-            }
-          });
-        }
-
-        let queueSize = queue.size + queue.pending;
-        queue.on('next', async () => {
-          if (callbackSyncProcess !== undefined) {
-            await callbackSyncProcess(queueSize - queue.pending, queueSize);
+          if (potentialErrors.length >= 3) {
+            potentialErrors.push(new Error("too many errors, stop the remaining tasks"));
+            queue.pause();
+            queue.clear();
           }
-        });
-        
-        await queue.onIdle();
+        })
+      }
 
-        if (potentialErrors.length > 0) {
-          if (tooManyErrors) {
-            potentialErrors.push(
-              new Error("too many errors, stop the remaining tasks")
-            );
-          }
-          throw new AggregateError(potentialErrors);
+      const queueSize = queue.size + queue.pending;
+
+      queue.on('next', async () => {
+        if (callbackSyncProcess !== undefined) {
+          const unsyncedItems = queue.size + queue.pending;
+          await callbackSyncProcess(unsyncedItems, queueSize);
         }
+      });
+
+      await queue.onIdle();
+
+      if (potentialErrors.length > 0) {
+        throw new AggregateError(potentialErrors);
       }
     }
   }
@@ -1453,5 +1431,5 @@ export const doActualSync = async (
     password
   );
 
-  log.debug(`finish syncing extra data`);
+  log.debug(`finish syncing extra data lastly`);
 };


### PR DESCRIPTION
- Fixes #98 and stop syncs running more than once. syncRun only had a check to stop manual syncing if the sync is already running but ignored it for the other sync trigger types. Let me know if this was intended behaviour or not. 

- Fixes Sync on Remote not running on file modification. This is because the metadata would only upload/change if there was deletions. Removed the check for this so that metadata is uploaded on every sync regardless if it is the same.

- Fixes metadata not uploading if the concurrency is 1 and refactors the doActualSync code.

- Fixes #68 and mostly fixes #46. There are still occassions where the status bar flashes to something else, #102.

- Fixes bug found in #98 where metadata could sync before sync completes. Additionally, it fixes all logged statements being out of order. Syncing concurrently will appear out of order because they finish at different times, but all the start syncing will be in order.

~~Fixing metadata not uploading if the concurrency is 1 added an if statement to the already many nested for loops. I think that section needs a refactor so that the queue can upload at a concurrency of 1 (if that is possible). So that we can just delete the whole check for concurrency being 1.~~

