### PR TITLE
Fix sync status numerator counting down instead of up

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1407,7 +1407,7 @@ export const doActualSync = async (
 
       queue.on('next', async () => {
         if (callbackSyncProcess !== undefined) {
-          const unsyncedItems = queue.size + queue.pending;
+          const unsyncedItems = queueSize - (queue.size + queue.pending);
           await callbackSyncProcess(unsyncedItems, queueSize);
         }
       });


### PR DESCRIPTION
A commit I forgot to push for the last PR. (My bad)

Fixes the numerator starting at the queue size and counting down.