### PR TITLE
Status bar fixes + refactor

### DIFF
--- a/src/baseTypes.ts
+++ b/src/baseTypes.ts
@@ -90,7 +90,7 @@ export interface RemotelySavePluginSettings {
   logToDB?: boolean;
   skipSizeLargerThan?: number;
   enableStatusBarInfo: boolean;
-  lastSuccessSync?: number;
+  lastSynced?: number;
   trashLocal: boolean;
   syncTrash: boolean;
   syncBookmarks: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -482,7 +482,7 @@ export default class RemotelySavePlugin extends Plugin {
         //this.i18n.t("syncrun_status_syncing");
       }
     }
-    
+
     if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
       this.statusBarElement.setText(this.syncStatusText);
     }
@@ -1113,8 +1113,8 @@ export default class RemotelySavePlugin extends Plugin {
 
       const metadataMtime = await this.getMetadataMtime();
 
-      if (metadataMtime !== this.lastSynced) {
-        log.debug("Sync on Remote ran | Remote Metadata:", metadataMtime + ", Last Synced:", this.lastSynced);
+      if (metadataMtime !== this.settings.lastSynced) {
+        log.debug("Sync on Remote ran | Remote Metadata:", metadataMtime + ", Last Synced:", this.settings.lastSynced);
         this.syncRun("auto");
       }
     }, this.settings.syncOnRemoteChangesAfterMilliseconds);

--- a/src/main.ts
+++ b/src/main.ts
@@ -458,6 +458,36 @@ export default class RemotelySavePlugin extends Plugin {
     }
   }
 
+  private updateStatusBar(syncQueue?: {i: number, total: number}) {
+    if (this.statusBarElement === undefined) return;
+
+    if (this.syncStatus === "idle") {
+      const lastSynced = getLastSynced(this.i18n, this.settings.lastSynced);
+      this.syncStatusText = lastSynced.lastSyncMsg;
+      this.statusBarElement.setAttribute("aria-label", lastSynced.lastSyncLabelMsg);
+    } 
+    
+    if (this.syncStatus === "preparing") {
+      this.syncStatusText = this.i18n.t("syncrun_status_preparing");
+    }
+
+    if (this.syncStatus === "syncing") {
+      if (syncQueue !== undefined) {
+        this.syncStatusText = this.i18n.t("syncrun_status_progress", {
+          current: syncQueue.i.toString(),
+          total: syncQueue.total.toString()
+        });  
+      } else {
+        this.syncStatusText = "Syncing";
+        //this.i18n.t("syncrun_status_syncing");
+      }
+    }
+    
+    if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
+      this.statusBarElement.setText(this.syncStatusText);
+    }
+  }
+
   async onload() {
     this.oauth2Info = {
       verifier: "",
@@ -1163,33 +1193,6 @@ export default class RemotelySavePlugin extends Plugin {
   async saveAgreeToUseNewSyncAlgorithm() {
     this.settings.agreeToUploadExtraMetadata = true;
     await this.saveSettings();
-  }
-
-  updateStatusBar(syncQueue?: {i: number, total: number}) {
-    if (this.statusBarElement === undefined) return;
-
-    if (this.syncStatus === "idle") {
-      const lastSynced = getLastSynced(this.i18n, this.settings.lastSynced);
-      this.syncStatusText = lastSynced.lastSyncMsg;
-      this.statusBarElement.setAttribute("aria-label", lastSynced.lastSyncLabelMsg);
-    } 
-    
-    if (this.syncStatus === "preparing") {
-      this.syncStatusText === this.i18n.t("syncrun_status_preparing");
-    }
-
-    if (this.syncStatus === "syncing") {
-      if (syncQueue !== undefined) {
-        this.syncStatusText = this.i18n.t("syncrun_status_progress", {
-          current: syncQueue.i.toString(),
-          total: syncQueue.total.toString()
-        });  
-      }
-    }
-
-    if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
-      this.statusBarElement.setText(this.syncStatusText);
-    }
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   logToDB: false,
   skipSizeLargerThan: -1,
   enableStatusBarInfo: true,
-  lastSuccessSync: -1,
+  lastSynced: -1,
   trashLocal: false,
   syncTrash: false,
   syncBookmarks: true,
@@ -111,11 +111,10 @@ export default class RemotelySavePlugin extends Plugin {
   settings: RemotelySavePluginSettings;
   db: InternalDBs;
   syncStatus: SyncStatusType;
-  lastSynced: number;
+  syncStatusText?: string;
   statusBarElement: HTMLSpanElement;
   oauth2Info: OAuth2Info;
   currSyncMsg?: string;
-  syncingStatusText?: string;
   syncRibbon?: HTMLElement;
   autoRunIntervalID?: number;
   syncOnSaveIntervalID?: number;
@@ -204,16 +203,15 @@ export default class RemotelySavePlugin extends Plugin {
           serviceType: this.settings.serviceType,
         }), 1
       );
-      this.syncStatus = "preparing";
 
-      this.updateStatusBarText(t("syncrun_status_preparing"));
+      this.updateSyncStatus("preparing");
 
       getNotice(
         t("syncrun_step2", {
           maxSteps: `${MAX_STEPS}`,
         }), 2
       );
-      this.syncStatus = "getting_remote_files_list";
+      this.updateSyncStatus("getting_remote_files_list");
       const self = this;
       const client = this.getRemoteClient(self);
       const remoteRsp = await client.listFromRemote();
@@ -223,7 +221,8 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 3
       );
-      this.syncStatus = "checking_password";
+
+      this.updateSyncStatus("checking_password");
       
       const passwordCheckResult = await isPasswordOk(
         remoteRsp.Contents,
@@ -239,7 +238,7 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 4
       );
-      this.syncStatus = "getting_remote_extra_meta";
+      this.updateSyncStatus("getting_remote_extra_meta");
       const { remoteStates, metadataFile } = await this.parseRemoteItems(remoteRsp.Contents, client);
       const origMetadataOnRemote = await this.fetchMetadataFromRemote(metadataFile, client);
 
@@ -248,7 +247,7 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 5
       );
-      this.syncStatus = "getting_local_meta";
+      this.updateSyncStatus("getting_local_meta");
       const local = this.app.vault.getAllLoadedFiles();
       const localHistory = await this.getLocalHistory();
       let localConfigDirContents: ObsConfigDirFileType[] = await listFilesInObsFolder(this.app.vault, this.manifest.name, this.settings.syncTrash);
@@ -258,7 +257,8 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 6
       );
-      this.syncStatus = "generating_plan";
+
+      this.updateSyncStatus("generating_plan");
       const { plan, sortedKeys, deletions, sizesGoWrong } = await this.getSyncPlan(remoteStates, local, localConfigDirContents, origMetadataOnRemote, localHistory, client, triggerSource);
 
       await insertSyncPlanRecordByVault(this.db, plan, this.vaultRandomID);
@@ -273,10 +273,10 @@ export default class RemotelySavePlugin extends Plugin {
           }), 7
         );
 
-        this.syncStatus = "syncing";
+        this.updateSyncStatus("syncing");
         await this.doActualSync(client, plan, sortedKeys, metadataFile, origMetadataOnRemote, sizesGoWrong, deletions, self);
       } else {
-        this.syncStatus = "syncing";
+        this.updateSyncStatus("syncing");
         getNotice(
           t("syncrun_step7skip", {
             maxSteps: `${MAX_STEPS}`,
@@ -289,14 +289,13 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 8
       );
-      this.syncStatus = "finish";
 
-      this.updateLastSyncTime();
-      this.syncingStatusText = undefined;
+      this.updateSyncStatus("finish");
 
-      this.lastSynced = await this.getMetadataMtime();
+      this.settings.lastSynced = await this.getMetadataMtime();
+      this.saveSettings();
 
-      this.syncStatus = "idle";
+      this.updateSyncStatus("idle");
     } catch (error) {
       const msg = t("syncrun_abort", {
         manifestID: this.manifest.id,
@@ -314,12 +313,17 @@ export default class RemotelySavePlugin extends Plugin {
       } else {
         getNotice(error.message, -1, 10 * 1000);
       }
-      this.syncStatus = "idle";
+      this.updateSyncStatus("idle");
       if (this.syncRibbon !== undefined) {
         setIcon(this.syncRibbon, iconNameSyncWait);
         this.syncRibbon.setAttribute("aria-label", originLabel);
       }
     }
+  }
+
+  private updateSyncStatus(status: SyncStatusType) {
+    this.syncStatus = status;
+    this.updateStatusBar();
   }
 
   private async createTrashIfDoesNotExist() {
@@ -349,18 +353,6 @@ export default class RemotelySavePlugin extends Plugin {
     return originLabel;
   }
 
-  private updateLastSyncTime() {
-    this.settings.lastSuccessSync = Date.now();
-    this.saveSettings();
-
-    this.updateLastSuccessSyncMsg(this.settings.lastSuccessSync);
-
-    if (this.syncRibbon !== undefined) {
-      setIcon(this.syncRibbon, iconNameSyncWait);
-      this.syncRibbon.setAttribute("aria-label", this.getOriginLabel());
-    }
-  }
-
   private async doActualSync(client: RemoteClient, plan: SyncPlanType, sortedKeys: string[], metadataFile: FileOrFolderMixedState, origMetadataOnRemote: MetadataOnRemote, sizesGoWrong: FileOrFolderMixedState[], deletions: DeletionOnRemote[], self: this) {
     await doActualSync(
       client,
@@ -385,8 +377,7 @@ export default class RemotelySavePlugin extends Plugin {
           this.settings.password !== ""
         ).open();
       },
-      (i: number, totalCount: number) =>
-        self.setCurrSyncMsg(i, totalCount)
+      (i: number, total: number) => self.updateStatusBar({i, total})
     );
   }
 
@@ -527,7 +518,7 @@ export default class RemotelySavePlugin extends Plugin {
     // must AFTER preparing DB
     this.enableAutoClearSyncPlanHist();
 
-    this.syncStatus = "idle";
+    this.updateSyncStatus("idle");
 
     this.registerEvent(
       this.app.vault.on("delete", async (fileOrFolder) => {
@@ -748,11 +739,7 @@ export default class RemotelySavePlugin extends Plugin {
       this.statusBarElement = statusBarItem.createEl("span");
       this.statusBarElement.setAttribute("aria-label-position", "top");
 
-      this.updateLastSuccessSyncMsg(this.settings.lastSuccessSync);
-      // update statusbar text every 30 seconds
-      this.registerInterval(window.setInterval(() => {
-        this.updateLastSuccessSyncMsg(this.settings.lastSuccessSync);
-      }, 1000 * 30));
+      this.updateStatusBar();
     }
 
     this.addCommand({
@@ -822,19 +809,7 @@ export default class RemotelySavePlugin extends Plugin {
         id: "get-sync-status",
         name: t("command_syncstatus"),
         icon: iconNameStatusBar,
-        callback: async () => {
-          if (this.syncStatus === "idle") {
-            new Notice(getLastSynced(this.i18n, this.settings.lastSuccessSync).lastSyncMsg);
-          } else if (this.syncStatus === "syncing") {
-            if (this.syncingStatusText !== undefined) {
-              new Notice(this.syncingStatusText);
-            } else {
-              new Notice(t("syncrun_status_preparing"));
-            }
-          } else {
-            new Notice(t("syncrun_status_preparing"));
-          }
-        },
+        callback: () => new Notice(this.syncStatusText)
       });
     }
 
@@ -1193,35 +1168,43 @@ export default class RemotelySavePlugin extends Plugin {
     await this.saveSettings();
   }
 
-  async setCurrSyncMsg(
-    i: number,
-    totalCount: number
-  ) {
-    const text = this.i18n.t("syncrun_status_progress", {
-      current: i.toString(),
-      total: totalCount.toString()
-    });
-
-    this.syncingStatusText = text;
-
-    this.updateStatusBarText(text);
-  }
-
-  updateStatusBarText(statusText: string) {
+  updateStatusBar(syncQueue?: {i: number, total: number}) {
     if (this.statusBarElement === undefined) return;
-    if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
-      this.statusBarElement.setText(statusText);
+    
+    if (this.syncRibbon !== undefined) {
+      setIcon(this.syncRibbon, iconNameSyncWait);
+      this.syncRibbon.setAttribute("aria-label", this.getOriginLabel());
     }
-  }
 
-  // TODO: Refactor this into misc.ts or elsewhere
-  updateLastSuccessSyncMsg(lastSuccessSyncMillis?: number) {
-    if (this.statusBarElement === undefined) return;
+    if (this.syncStatus === "idle") {
+      const lastSynced = getLastSynced(this.i18n, this.settings.lastSynced);
 
-    const lastSynced = getLastSynced(this.i18n, lastSuccessSyncMillis);
+      // Update ribbon
+      // if (this.syncRibbon !== undefined) {
+      //   setIcon(this.syncRibbon, iconNameSyncWait);
+      //   this.syncRibbon.setAttribute("aria-label", this.getOriginLabel());
+      // }
 
-    this.statusBarElement.setText(lastSynced.lastSyncMsg);
-    this.statusBarElement.setAttribute("aria-label", lastSynced.lastSyncLabelMsg);
+      this.syncStatusText = lastSynced.lastSyncMsg;
+      this.statusBarElement.setAttribute("aria-label", lastSynced.lastSyncLabelMsg);
+    } 
+    
+    if (this.syncStatus === "preparing") {
+      this.syncStatusText === this.i18n.t("syncrun_status_preparing");
+    }
+
+    if (this.syncStatus === "syncing") {
+      if (syncQueue !== undefined) {
+        this.syncStatusText = this.i18n.t("syncrun_status_progress", {
+          current: syncQueue.i.toString(),
+          total: syncQueue.total.toString()
+        });  
+      }
+    }
+
+    if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
+      this.statusBarElement.setText(this.syncStatusText);
+    }
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1113,6 +1113,10 @@ export default class RemotelySavePlugin extends Plugin {
 
       const metadataMtime = await this.getMetadataMtime();
 
+      if (metadataMtime === undefined) {
+        return;
+      }
+
       if (metadataMtime !== this.settings.lastSynced) {
         log.debug("Sync on Remote ran | Remote Metadata:", metadataMtime + ", Last Synced:", this.settings.lastSynced);
         this.syncRun("auto");

--- a/src/main.ts
+++ b/src/main.ts
@@ -478,8 +478,7 @@ export default class RemotelySavePlugin extends Plugin {
           total: syncQueue.total.toString()
         });  
       } else {
-        this.syncStatusText = "Syncing";
-        //this.i18n.t("syncrun_status_syncing");
+        this.syncStatusText = this.i18n.t("syncrun_status_syncing");
       }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,11 +315,6 @@ export default class RemotelySavePlugin extends Plugin {
     }
   }
 
-  private updateSyncStatus(status: SyncStatusType) {
-    this.syncStatus = status;
-    this.updateStatusBar();
-  }
-
   private async createTrashIfDoesNotExist() {
     if (this.settings.syncTrash) {
       // when syncing to a device which never trashed a file we will error if this folder does not exist
@@ -434,6 +429,11 @@ export default class RemotelySavePlugin extends Plugin {
       () => self.saveSettings()
     );
     return client;
+  }
+
+  private updateSyncStatus(status: SyncStatusType) {
+    this.syncStatus = status;
+    this.updateStatusBar();
   }
 
   private setSyncIcon(running: boolean, triggerSource?: "manual" | "auto" | "dry" | "autoOnceInit") {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -200,7 +200,7 @@ class ChangeRemoteBaseDirModal extends Modal {
           button.onClick(async () => {
             this.plugin.settings[this.service].remoteBaseDir =
               this.newRemoteBaseDir;
-            this.plugin.settings.lastSuccessSync = -1;
+            this.plugin.settings.lastSynced = -1;
             await this.plugin.saveSettings();
             new Notice(t("modal_remotebasedir_notice"));
             this.close();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1403,15 +1403,17 @@ export const doActualSync = async (
         })
       }
 
-      const queueSize = queue.size + queue.pending;
+      if (operation === nested[2]) {
+        const queueSize = queue.size + queue.pending;
 
-      queue.on('next', async () => {
-        if (callbackSyncProcess !== undefined) {
-          const unsyncedItems = queue.size + queue.pending;
-          await callbackSyncProcess(unsyncedItems, queueSize);
-        }
-      });
-
+        queue.on('next', async () => {
+          if (callbackSyncProcess !== undefined) {
+            const unsyncedItems = queueSize - (queue.size + queue.pending);
+            await callbackSyncProcess(unsyncedItems, queueSize);
+          }
+        });
+      }
+      
       await queue.onIdle();
 
       if (potentialErrors.length > 0) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1321,7 +1321,7 @@ function isCountableSyncItem(item: FileOrFolderMixedState) {
   return item.decision != "keepRemoteDelHist" && !item.decision.contains("skip");
 }
 
-async function syncIndividualItem(key: string, val: FileOrFolderMixedState, vaultRandomID: string, client: RemoteClient, db: InternalDBs, vault: Vault, localDeleteFunc: any, password: string) {
+async function syncIndividualItem(key: string, deletionOp: boolean, val: FileOrFolderMixedState, vaultRandomID: string, client: RemoteClient, db: InternalDBs, vault: Vault, localDeleteFunc: any, password: string) {
   log.debug(`start syncing "${key}" with plan ${JSON.stringify(val)}`);
 
   await dispatchOperationToActual(
@@ -1334,7 +1334,10 @@ async function syncIndividualItem(key: string, val: FileOrFolderMixedState, vaul
     localDeleteFunc,
     password
   );
+
   log.debug(`finished ${key}`);
+
+  return deletionOp;
 }
 
 export const doActualSync = async (
@@ -1360,36 +1363,50 @@ export const doActualSync = async (
     return;
   }
 
+  // Get and print sync info
+
   log.debug(`concurrency === ${concurrency}`);
 
   const { folderCreationOps, deletionOps, uploadDownloads, realTotalCount } =  splitThreeSteps(syncPlan, sortedKeys);
   const nested = [folderCreationOps, deletionOps, uploadDownloads];
-  const logTexts = [
-    `1. create all folders from shadowest to deepest, also check undefined decision`,
-    `2. delete files and folders from deepest to shadowest`,
-    `3. upload or download files in parallel, with the desired concurrency=${concurrency}`,
-  ];
 
   log.debug("folderCreationOps: ", folderCreationOps.length,
   " deletionOps: ", deletionOps.length,
   " uploadDownloads: ", uploadDownloads.length);
 
+  // Prepare sync queue
+
+  const queue = new PQueue({ concurrency: concurrency, autoStart: true });
+  let queueTotal = 0;
+  let queueIndex = 0;
+
+  queue.on('completed', async (result) => {
+    if (result !== true) {
+      queueIndex++;
+
+      await callbackSyncProcess(queueIndex, queueTotal);
+    }
+  });
+
   // Sync files in order of folder creation, deletions and uploads/downloads
-  // Must be for of to stop rest of code running before promises resolve
+
+  const potentialErrors: Error[] = [];
+
   for (const operation of nested) {
     for (const singleLevelOps of operation) {
       if (singleLevelOps === undefined || singleLevelOps === null) {
         continue;
       }
 
-      const queue = new PQueue({ concurrency: concurrency, autoStart: true });
-      const potentialErrors: Error[] = [];
-
-      for (let i = 0; i < singleLevelOps.length; ++i) {
-        const val: FileOrFolderMixedState = singleLevelOps[i];
+      for (const val of singleLevelOps) {
         const key = val.key;
+        const isDeleteOp = operation === deletionOps;
 
-        const syncCall = queue.add(async () => await syncIndividualItem(key, val, vaultRandomID, client, db, vault, localDeleteFunc, password));
+        if (isDeleteOp === false) {
+          queueTotal++;
+        }
+
+        const syncCall = queue.add(async () => await syncIndividualItem(key, isDeleteOp, val, vaultRandomID, client, db, vault, localDeleteFunc, password));
 
         syncCall.catch((error) => {
           const message = `${key}: ${error.message}`;
@@ -1402,24 +1419,15 @@ export const doActualSync = async (
           }
         })
       }
-
-      if (operation === nested[2]) {
-        const queueSize = queue.size + queue.pending;
-
-        queue.on('next', async () => {
-          if (callbackSyncProcess !== undefined) {
-            const unsyncedItems = queueSize - (queue.size + queue.pending);
-            await callbackSyncProcess(unsyncedItems, queueSize);
-          }
-        });
-      }
-      
-      await queue.onIdle();
-
-      if (potentialErrors.length > 0) {
-        throw new AggregateError(potentialErrors);
-      }
     }
+  }
+
+  await queue.onIdle();
+
+  // Sync end
+
+  if (potentialErrors.length > 0) {
+    throw new AggregateError(potentialErrors);
   }
 
   log.debug(`start syncing extra data lastly`);


### PR DESCRIPTION
- Fixes #102 as I refactored how the status bar is updated. Made it so the status bar is updated whenever the plugin's syncStatus variable is updated. This cleaned up the syncRun code a lot as it doesn't have to worry about updating the status bar anymore (just the sync status).
- Fixes #104. All the operations are on the same queue now. Made it so that deletion ops don't update the status bar. In the case the user doesn't upload folders, or upload/downloads, the status bar would only switch to preparing (no sync info gets given). So to fix this I added a 'Syncing' in the lang. This is noticeable when the user syncs on no changes.
- Stops Sync on Remote running if there is no metadata.
- Made it so Sync on Remote only runs on start up if there has been a remote sync. (Made last sync on settings so it persists)
- Fixed the ribbon bar's aria label not resetting after a sync. Would be stuck as 'Remotely Sync: manual'.

Please let me know your opinion on this PR and if you wan't anything changed.