### PR TITLE
Fixed status bar issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1108,7 +1108,7 @@ export default class RemotelySavePlugin extends Plugin {
         if (this.syncStatus !== "syncing") {
           this.updateStatusBar();
         }
-      }, 60_000);
+      }, 30_000);
 
       this.updateStatusBar();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1096,7 +1096,7 @@ export default class RemotelySavePlugin extends Plugin {
 
   // Needed to update text for get command
   toggleStatusText(enabled: boolean) {
-    // Remove interval
+    // Clears the current interval
     if (this.statusBarIntervalID !== undefined) {
       window.clearInterval(this.statusBarIntervalID);
       this.statusBarIntervalID = undefined;
@@ -1104,15 +1104,13 @@ export default class RemotelySavePlugin extends Plugin {
 
     // Set up interval
     if (enabled) {
-      const interval = window.setInterval(async () => {
-        if (this.syncStatus === "syncing") {
-          return;
+      this.statusBarIntervalID = window.setInterval(async () => {
+        if (this.syncStatus !== "syncing") {
+          this.updateStatusBar();
         }
-        console.log(interval);
-        this.updateStatusBar();
-      }, 5_000);
+      }, 60_000);
 
-      this.statusBarIntervalID = interval; 
+      this.updateStatusBar();
     }
   }
 
@@ -1140,7 +1138,6 @@ export default class RemotelySavePlugin extends Plugin {
     }
 
     this.syncOnRemoteIntervalID = window.setInterval(async () => {
-      // Tries to prevent it from running multiple setIntervals
       if (this.syncStatus !== "idle") {
         return;
       }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1687,7 +1687,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
             .onChange(async (val) => {
               this.plugin.settings.enableStatusBarInfo = val;
               await this.plugin.saveSettings();
-              new Notice(t("settings_enablestatusbar_reloadrequired_notice"));
+              this.plugin.toggleStatusBar(val);
             });
         });
     }


### PR DESCRIPTION
- Fixed status bar last sync not updating until synced again.
- Made it so status bar toggle in settings doesn't require a restart.

Also just letting you know I made slight changes to some bits in Sync on Remote. I also noticed an issue on mobile where the get status command doesn't show anything. Made it so the command can be used on desktop and it seems to work. Will check after this update and if it doesn't work, I'll look into it.