### PR TITLE
Add Remote Change Sync Notices

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -136,24 +136,22 @@ export default class RemotelySavePlugin extends Plugin {
     };
 
     const getNotice = (x: string, step: number, timeout?: number) => {
-      // only show notices in manual mode
-      // no notice in auto mode
+      // only show notices in manual mode no notice in auto mode
       if (this.isManual || triggerSource === "manual" || triggerSource === "dry") {
+        // Display Mobile Notices
         if (!this.settings.debugEnabled) {
-          // If not mobile and status bar enabled, return.
-          if (!Platform.isMobileApp && this.settings.enableStatusBarInfo === true) {
-            return;
+          if (Platform.isMobile) {
+            if (step == 1) {
+              new Notice("1/" + this.i18n.t("syncrun_step8", {maxSteps: "2"}), timeout);
+            } else if (step == 8) {
+              new Notice("2/" + this.i18n.t("syncrun_step8", {maxSteps: "2"}), timeout);
+            }
           }
 
-          // Rewrite step 8 to display as step 2
-          if (step == 8) {
-            step = 2;
-          } else if (step > 1 && step < 8) {
-            // Allow all errors ("step -1"). Otherwise skip steps 2 -> 7
-            return;
-          }
+          return;
         }
-        // Add "step/x" in notice
+
+        // Display debug notices
         const prefix = step > -1 ? step + "/" : "";
         new Notice(prefix + x, timeout);
       }
@@ -162,16 +160,13 @@ export default class RemotelySavePlugin extends Plugin {
     // Make sure two syncs can't run at the same time
     if (this.syncStatus !== "idle") {
       if (triggerSource == "manual") {
-        new Notice(
-          "1/" + t("syncrun_alreadyrunning", {
-            maxSteps: `${MAX_STEPS}`,
-            pluginName: this.manifest.name,
-            syncStatus: this.syncStatus,
-          })
-        );
-
-        // If already running, report finished status as user tried to manually sync
-        this.isManual = true;
+        // Show notice for debug, mobile, or desktop
+        if (this.settings.debugEnabled) {
+          new Notice(t("syncrun_debug_alreadyrunning", { stage: this.syncStatus}));
+        } else {
+          new Notice(Platform.isMobile ? 
+            t("syncrun_mobile_alreadyrunning") : t("syncrun_desktop_alreadyrunning"));
+        }
 
         log.debug(this.manifest.name, " already running in stage: ", this.syncStatus);
 
@@ -179,7 +174,7 @@ export default class RemotelySavePlugin extends Plugin {
           log.debug(this.currSyncMsg);
         }  
       }
-      
+
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,6 @@ import {
 } from "./debugMode";
 import { SizesConflictModal } from "./syncSizesConflictNotice";
 import {mkdirpInVault, getLastSynced} from "./misc";
-import { platform } from "os";
 
 const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   s3: DEFAULT_S3_CONFIG,

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,11 +138,13 @@ export default class RemotelySavePlugin extends Plugin {
     const getNotice = (x: string, step: number, timeout?: number) => {
       // only show notices in manual mode no notice in auto mode
       if (this.isManual || triggerSource === "manual" || triggerSource === "dry") {
-        // Display Mobile Notices
+        // Display mobile or desktop without status bar notices
         if (!this.settings.debugEnabled) {
-          if (Platform.isMobile) {
+          if (Platform.isMobile || !this.settings.enableStatusBarInfo) {
             if (step == 1) {
-              new Notice("1/" + this.i18n.t("syncrun_step8", {maxSteps: "2"}), timeout);
+              new Notice("1/" + this.i18n.t("syncrun_step1", {
+                maxSteps: "2", serviceType: this.settings.serviceType
+              }), timeout);
             } else if (step == 8) {
               new Notice("2/" + this.i18n.t("syncrun_step8", {maxSteps: "2"}), timeout);
             }
@@ -162,10 +164,9 @@ export default class RemotelySavePlugin extends Plugin {
       if (triggerSource == "manual") {
         // Show notice for debug, mobile, or desktop
         if (this.settings.debugEnabled) {
-          new Notice(t("syncrun_debug_alreadyrunning", { stage: this.syncStatus}));
+          new Notice(t("syncrun_debug_alreadyrunning", {stage: this.syncStatus}));
         } else {
-          new Notice(Platform.isMobile ? 
-            t("syncrun_mobile_alreadyrunning") : t("syncrun_desktop_alreadyrunning"));
+          new Notice(t("syncrun_alreadyrunning"));
         }
 
         log.debug(this.manifest.name, " already running in stage: ", this.syncStatus);


### PR DESCRIPTION
Hi just some small changes to the notices.
- Added #110. A notice now shows on load saying whether the vault is up to date or needs to sync if Sync On Remote is enabled. Also shows when Sync On Remote is toggled in the settings.
- Fixed #71 by cleaning up the already running notices code. I also noticed in debug mode it displayed (1/8) even if the step wasn't 1. I fixed it to the correct step but found it looked weird and wasn't useful, so I made it display "Remotely Sync already running in stage: {{stage}}".