### PR TITLE
Small fixes and Agreement Modal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -287,6 +287,7 @@ export default class RemotelySavePlugin extends Plugin {
 
       this.updateSyncStatus("finish");
 
+      // This needs to be done differently as getting the mTime from the remote is slow
       this.settings.lastSynced = await this.getMetadataMtime();
       this.saveSettings();
 
@@ -548,8 +549,6 @@ export default class RemotelySavePlugin extends Plugin {
 
     // must AFTER preparing DB
     this.enableAutoClearSyncPlanHist();
-
-    this.updateSyncStatus("idle");
 
     this.registerEvent(
       this.app.vault.on("delete", async (fileOrFolder) => {
@@ -850,6 +849,8 @@ export default class RemotelySavePlugin extends Plugin {
       this.toggleSyncOnSave(true);
       this.toggleStatusBar(true);
       this.toggleStatusText(true);
+
+      this.updateSyncStatus("idle");
     }
   }
 

--- a/src/syncAlgoV2Notice.ts
+++ b/src/syncAlgoV2Notice.ts
@@ -20,11 +20,10 @@ export class SyncAlgoV2Modal extends Modal {
       text: this.i18n.t("syncalgov2_title"),
     });
 
-    const ul = contentEl.createEl("ul");
     this.i18n.t("syncalgov2_texts")
       .split("\n")
       .forEach((val) => {
-        ul.createEl("li", {
+        contentEl.createEl("p", {
           text: val,
         });
       });

--- a/src/syncAlgoV2Notice.ts
+++ b/src/syncAlgoV2Notice.ts
@@ -1,29 +1,27 @@
-import { App, Modal, Notice, PluginSettingTab, Setting } from "obsidian";
-import type RemotelySavePlugin from "./main"; // unavoidable
-import type { TransItemType } from "./i18n";
-
-import { log } from "./moreOnLog";
+import { App, Modal, Setting } from "obsidian";
+import type { I18n } from "./i18n";
 
 export class SyncAlgoV2Modal extends Modal {
-  agree: boolean;
-  readonly plugin: RemotelySavePlugin;
-  constructor(app: App, plugin: RemotelySavePlugin) {
+  result: boolean;
+  onSubmit: (result: boolean) => void;
+  i18n: I18n;
+
+  constructor(app: App, i18n: I18n, onSubmit: (result: boolean) => void) {
     super(app);
-    this.plugin = plugin;
-    this.agree = false;
+    this.i18n = i18n;
+    this.result = false;
+    this.onSubmit = onSubmit;
   }
+
   onOpen() {
     let { contentEl } = this;
-    const t = (x: TransItemType, vars?: any) => {
-      return this.plugin.i18n.t(x, vars);
-    };
 
     contentEl.createEl("h2", {
-      text: t("syncalgov2_title"),
+      text: this.i18n.t("syncalgov2_title"),
     });
 
     const ul = contentEl.createEl("ul");
-    t("syncalgov2_texts")
+    this.i18n.t("syncalgov2_texts")
       .split("\n")
       .forEach((val) => {
         ul.createEl("li", {
@@ -33,14 +31,14 @@ export class SyncAlgoV2Modal extends Modal {
 
     new Setting(contentEl)
       .addButton((button) => {
-        button.setButtonText(t("syncalgov2_button_agree"));
+        button.setButtonText(this.i18n.t("syncalgov2_button_agree"));
         button.onClick(async () => {
-          this.agree = true;
+          this.result = true;
           this.close();
         });
       })
       .addButton((button) => {
-        button.setButtonText(t("syncalgov2_button_disagree"));
+        button.setButtonText(this.i18n.t("syncalgov2_button_disagree"));
         button.onClick(() => {
           this.close();
         });
@@ -50,12 +48,7 @@ export class SyncAlgoV2Modal extends Modal {
   onClose() {
     let { contentEl } = this;
     contentEl.empty();
-    if (this.agree) {
-      this.plugin.saveAgreeToUseNewSyncAlgorithm();
-      this.plugin.enableAutoSyncIfSet();
-      this.plugin.enableInitSyncIfSet();
-    } else {
-      this.plugin.unload();
-    }
+
+    this.onSubmit(this.result);
   }
 }


### PR DESCRIPTION
Should fix #120.

I refactored the agreement modal and made it so it only handles 'being a modal' (changing settings is done in main now). After the settings load, the plugin prompts for the modal if they haven't agreed yet. If they agree it will continue with the rest of the onLoad as usual. This should fix the issue since before if they hadn't agreed, it wouldn't toggle the features on.

I also [updated](https://github.com/sboesen/langs/pull/29) the lang for the modal as well.