### PR TITLE
Fix mobile status bar issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -87,8 +87,8 @@ const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   lang: "auto",
   logToDB: false,
   skipSizeLargerThan: -1,
-  enableStatusBarInfo: true,
-  showLastSyncedOnly: false,
+  enableStatusBarInfo: undefined,
+  showLastSyncedOnly: undefined,
   lastSynced: -1,
   trashLocal: false,
   syncTrash: false,
@@ -854,6 +854,18 @@ export default class RemotelySavePlugin extends Plugin {
     });
     
     this.addSettingTab(new RemotelySaveSettingTab(this.app, this));
+
+    // Show status bar show by default on desktop only
+    if (this.settings.enableStatusBarInfo === undefined) {
+      this.settings.enableStatusBarInfo = Platform.isMobile ? false : true;
+    }
+
+    // Hide all other elements in status bar by default on mobile only
+    if (this.settings.showLastSyncedOnly === undefined) {
+      this.settings.enableStatusBarInfo = Platform.isMobile ? true : false;
+    }
+
+    this.saveSettings();
 
     // this.registerDomEvent(document, "click", (evt: MouseEvent) => {
     //   log.info("click", evt);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1076,27 +1076,35 @@ export default class RemotelySavePlugin extends Plugin {
   toggleStatusBar(enabled: boolean) {  
     this.statusBarElement?.remove();
 
-    const statusBar = document.getElementsByClassName("status-bar")[0];
+    const statusBar = document.getElementsByClassName("status-bar")[0] as HTMLElement;
 
-    // Enable status bar for mobile
-    if (Platform.isMobile) {
-      (statusBar as HTMLElement).style.display = this.settings.enableStatusBarInfo ? "flex" : "none";
-    }
+    // Remove any remotely sync classes
+    statusBar.removeClass("remotely-sync-show-status-bar");
+    statusBar.removeClass("remotely-sync-shift-status-bar");
+
+    Array.from(statusBar.children).forEach((element) => {
+      element.removeClass("remotely-sync-hidden");
+    });
 
     if (enabled && this.settings.enableStatusBarInfo) {
-      // Show all default elements
-      Array.from(statusBar.children).forEach((element) => {
-        (element as HTMLElement).removeClass("hide-element");
-      });
+      // Enable status bar on mobile
+      if (Platform.isMobile) {
+        statusBar.addClass("remotely-sync-show-status-bar");
+        
+        // Shifts up the status bar on phone to not cover the navmenu
+        if (Platform.isPhone) {
+          statusBar.addClass("remotely-sync-shift-status-bar");
+        }
+      }
 
+      // Hide every element if set
       if (this.settings.showLastSyncedOnly)  {
-        // Hide all default elements
-        log.debug("HIde all elements")
         Array.from(statusBar.children).forEach((element) => {
-          (element as HTMLElement).addClass("hide-element");
+          (element as HTMLElement).addClass("remotely-sync-hidden");
         });
       }
 
+      // Create remotely sync element
       this.statusBarElement = this.addStatusBarItem();
       this.statusBarElement.createEl("span");
       this.statusBarElement.setAttribute("data-tooltip-position", "top");    

--- a/src/main.ts
+++ b/src/main.ts
@@ -1059,21 +1059,21 @@ export default class RemotelySavePlugin extends Plugin {
   }
 
   toggleStatusBar(enabled: boolean) {  
-    const statusBar = document.getElementsByClassName("status-bar")[0];
-
     this.statusBarElement?.remove();
 
-    // Show all default elements
-    statusBar.childNodes.forEach((element) => {
-      (element as HTMLElement).style.display = "flex";
-    });
-
-    // Enable status bar for mobile
-    if (Platform.isMobile) {
-      (statusBar as HTMLElement).style.display = enabled ? "flex" : "none";
-    }
-
     if (enabled && this.settings.enableStatusBarInfo) {
+      const statusBar = document.getElementsByClassName("status-bar")[0];
+
+      // Show all default elements
+      statusBar.childNodes.forEach((element) => {
+        (element as HTMLElement).style.display = "flex";
+      });
+
+      // Enable status bar for mobile
+      if (Platform.isMobile) {
+        (statusBar as HTMLElement).style.display = enabled ? "flex" : "none";
+      }
+
       if (this.settings.showLastSyncedOnly)  {
         // Hide all default elements
         statusBar.childNodes.forEach((element) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1076,23 +1076,24 @@ export default class RemotelySavePlugin extends Plugin {
   toggleStatusBar(enabled: boolean) {  
     this.statusBarElement?.remove();
 
+    const statusBar = document.getElementsByClassName("status-bar")[0];
+
+    // Enable status bar for mobile
+    if (Platform.isMobile) {
+      (statusBar as HTMLElement).style.display = this.settings.enableStatusBarInfo ? "flex" : "none";
+    }
+
     if (enabled && this.settings.enableStatusBarInfo) {
-      const statusBar = document.getElementsByClassName("status-bar")[0];
-
       // Show all default elements
-      statusBar.childNodes.forEach((element) => {
-        (element as HTMLElement).style.display = "flex";
+      Array.from(statusBar.children).forEach((element) => {
+        (element as HTMLElement).removeClass("hide-element");
       });
-
-      // Enable status bar for mobile
-      if (Platform.isMobile) {
-        (statusBar as HTMLElement).style.display = enabled ? "flex" : "none";
-      }
 
       if (this.settings.showLastSyncedOnly)  {
         // Hide all default elements
-        statusBar.childNodes.forEach((element) => {
-          (element as HTMLElement).style.display = "none";
+        log.debug("HIde all elements")
+        Array.from(statusBar.children).forEach((element) => {
+          (element as HTMLElement).addClass("hide-element");
         });
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -862,7 +862,7 @@ export default class RemotelySavePlugin extends Plugin {
 
     // Hide all other elements in status bar by default on mobile only
     if (this.settings.showLastSyncedOnly === undefined) {
-      this.settings.enableStatusBarInfo = Platform.isMobile ? true : false;
+      this.settings.showLastSyncedOnly = Platform.isMobile ? true : false;
     }
 
     this.saveSettings();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1658,16 +1658,16 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
             this.plugin.toggleStatusBar(val);
 
             statusBarOptions.toggleClass(
-              "hide-element",
+              "remotely-sync-hidden",
               this.plugin.settings.enableStatusBarInfo !== true
             );
           });
       });
 
-    const statusBarOptions = basicDiv.createDiv({ cls: "hide-element" });
+    const statusBarOptions = basicDiv.createDiv({ cls: "remotely-sync-hidden" });
 
     statusBarOptions.toggleClass(
-      "hide-element",
+      "remotely-sync-hidden",
       this.plugin.settings.enableStatusBarInfo !== true
     );
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1681,6 +1681,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
           this.plugin.settings.showLastSyncedOnly = val;
           await this.plugin.saveSettings();
           this.plugin.toggleStatusBar(true);
+          this.plugin.toggleStatusBarObserver(val);
         });
     });
 

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,15 @@
   height: 350px;
 }
 
-.hide-element {
-  display: none;
+/* !important isn't great practice but it needs to overwrite other css classes */
+.remotely-sync-hidden {
+  display: none !important; 
+}
+
+.remotely-sync-show-status-bar {
+  display: flex !important;
+}
+
+.remotely-sync-shift-status-bar {
+  margin-bottom: 48px !important;
 }


### PR DESCRIPTION
Hopefully fixes all this. I tested on pc and mobile and it seems to work pretty well for me.
- Fixes status bar showing over navmenu on mobile by moving it up #124.
- Also fixes status bar not hiding new elements that are added to it with only show last synced on #124.
- Fixes the default settings. Now on computer status bar will default to on but only show last synced off. While on mobile status bar will default to off, but show only last synced defaults to true.

To explain what I did. I created a Mutation Observer that watches the status bar element for any children added and reloading the status bar to hide them when there are. The reason this has its own toggle function is so that the observer can be disabled when show only last synced is off, since it's not needed then.