### PR TITLE
Refactor getting remote metadata

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ import { DEFAULT_S3_CONFIG } from "./remoteForS3";
 import { DEFAULT_WEBDAV_CONFIG } from "./remoteForWebdav";
 import { RemotelySaveSettingTab } from "./settings";
 import {fetchMetadataFile, parseRemoteItems, SyncPlanType, SyncStatusType} from "./sync";
-import { doActualSync, getSyncPlan, isPasswordOk, getMetadataPath } from "./sync";
+import { doActualSync, getSyncPlan, isPasswordOk, getMetadataFromRemoteFiles } from "./sync";
 import { messyConfigToNormal, normalConfigToMessy } from "./configPersist";
 import { ObsConfigDirFileType, listFilesInObsFolder } from "./obsFolderLister";
 import { I18n } from "./i18n";
@@ -1218,10 +1218,11 @@ export default class RemotelySavePlugin extends Plugin {
   
   async getMetadataMtime() {
     const client = this.getRemoteClient(this);
+    
+    const remoteFiles = await client.listFromRemote();
+    const remoteMetadataFile = await getMetadataFromRemoteFiles(remoteFiles.Contents, this.settings.password);
 
-    const path = await getMetadataPath();
-    const remoteMetadata = await client.getMetadataFromRemote(path);
-    const lastSynced = remoteMetadata.lastModified
+    const lastSynced = remoteMetadataFile.lastModified;
 
     if (lastSynced === undefined && this.settings.lastSynced !== undefined) {
       return this.settings.lastSynced;

--- a/src/obsFolderLister.ts
+++ b/src/obsFolderLister.ts
@@ -29,10 +29,10 @@ const isFolderToSkip = (x: string) => {
 
 const isPluginDirItself = (x: string, pluginId: string) => {
   return (
-    x === pluginId ||
-    x === `${pluginId}/` ||
-    x.endsWith(`/${pluginId}`) ||
-    x.endsWith(`/${pluginId}/`)
+    x === "remotely-secure" ||
+    x === "remotely-secure/" ||
+    x.endsWith("/remotely-secure") ||
+    x.endsWith("/remotely-secure/")
   );
 };
 

--- a/src/obsFolderLister.ts
+++ b/src/obsFolderLister.ts
@@ -110,6 +110,7 @@ export const listFilesInObsFolder = async (
             if (isFolderToSkip(iter2)) {
               continue;
             }
+            
             if (isInsideSelfPlugin && !isLikelyPluginSubFiles(iter2)) {
               // special treatment for remotely-secure folder
               continue;

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -254,18 +254,6 @@ export class RemoteClient {
     }
   };
 
-  getMetadataFromRemote = async (fileOrFolderPath: string ) => {
-    if (this.serviceType === "dropbox") {
-      return await dropbox.getRemoteMeta(this.dropboxClient, fileOrFolderPath);
-    } else if (this.serviceType === "s3") {
-      return await s3.getRemoteMeta(s3.getS3Client(this.s3Config), this.s3Config, fileOrFolderPath);
-    } else if (this.serviceType === "onedrive") {
-      return await onedrive.getRemoteMeta(this.onedriveClient, fileOrFolderPath);
-    } else if (this.serviceType === "webdav") {
-      return await webdav.getRemoteMeta(this.webdavClient, fileOrFolderPath);
-    }
-  };
-
   checkConnectivity = async (callbackFunc?: any) => {
     if (this.serviceType === "s3") {
       return await s3.checkConnectivity(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -137,6 +137,25 @@ export const getMetadataFiles = async(
   return metadataFiles;
 }
 
+export const getMetadataFromRemoteFiles = async(
+  remoteFiles: RemoteItem[],
+  password: string = ""
+)=> {
+  for (const entry of remoteFiles) {
+    const remoteEncryptedKey = entry.key;
+
+    let key = remoteEncryptedKey;
+
+    if (password !== "") {
+      key = await decryptBase64urlToString(remoteEncryptedKey, password);
+    }
+
+    if (key == DEFAULT_FILE_NAME_FOR_METADATAONREMOTE) {
+      return entry;
+    }
+  }
+}
+
 export const parseRemoteItems = async (
   remote: RemoteItem[],
   db: InternalDBs,
@@ -1078,16 +1097,6 @@ export const uploadExtraMeta = async (
     true,
     resultText
   );
-};
-
-export const getMetadataPath = async (password: string = "") => {
-  let key = DEFAULT_FILE_NAME_FOR_METADATAONREMOTE;
-
-  if (password !== "") {
-    key = await encryptStringToBase64url(key, password);
-  }
-
-  return key;
 };
 
 const dispatchOperationToActual = async (

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1080,24 +1080,14 @@ export const uploadExtraMeta = async (
   );
 };
 
-export const getMetadataPath = async (metadataFile: FileOrFolderMixedState | undefined, password: string = "") => {
-  if (metadataFile === undefined) {
-    log.debug("no metadata file, so no file path");
-    return;
-  }
-
-  const key = DEFAULT_FILE_NAME_FOR_METADATAONREMOTE;
-  let remoteEncryptedKey = key;
+export const getMetadataPath = async (password: string = "") => {
+  let key = DEFAULT_FILE_NAME_FOR_METADATAONREMOTE;
 
   if (password !== "") {
-    remoteEncryptedKey = metadataFile.remoteEncryptedKey;
-
-    if (remoteEncryptedKey === undefined || remoteEncryptedKey === "") {
-      remoteEncryptedKey = await encryptStringToBase64url(key, password);
-    }
+    key = await encryptStringToBase64url(key, password);
   }
 
-  return remoteEncryptedKey;
+  return key;
 };
 
 const dispatchOperationToActual = async (


### PR DESCRIPTION
Very small refactor to getting the remote metadata last modified time.

- Sync on Remote will no longer spam the remote with requests to get metadata and will wait until the previous is finished.

Also I found that when getting all the files, "remotely-sync" files were being skipped instead of "remotely-secure".