### PR TITLE
Fix multiple metadatas issue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ import {
 import { DEFAULT_S3_CONFIG } from "./remoteForS3";
 import { DEFAULT_WEBDAV_CONFIG } from "./remoteForWebdav";
 import { RemotelySaveSettingTab } from "./settings";
-import {fetchMetadataFile, parseRemoteItems, SyncPlanType, SyncStatusType} from "./sync";
+import { getRemoteMetadata, parseRemoteItems, SyncPlanType, SyncStatusType } from "./sync";
 import { doActualSync, getSyncPlan, isPasswordOk, getMetadataFromRemoteFiles } from "./sync";
 import { messyConfigToNormal, normalConfigToMessy } from "./configPersist";
 import { ObsConfigDirFileType, listFilesInObsFolder } from "./obsFolderLister";
@@ -236,7 +236,12 @@ export default class RemotelySavePlugin extends Plugin {
         }), 4
       );
       this.updateSyncStatus("getting_remote_extra_meta");
+
+      const testmeta = await getMetadataFile(remoteRsp.Contents, client, this.settings.password);
+      const testStates = await getREmoteStates
+
       const { remoteStates, metadataFile } = await this.parseRemoteItems(remoteRsp.Contents, client);
+
       const origMetadataOnRemote = await this.fetchMetadataFromRemote(metadataFile, client);
 
       getNotice(
@@ -244,6 +249,7 @@ export default class RemotelySavePlugin extends Plugin {
           maxSteps: `${MAX_STEPS}`,
         }), 5
       );
+
       this.updateSyncStatus("getting_local_meta");
       const local = this.app.vault.getAllLoadedFiles();
       const localHistory = await this.getLocalHistory();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2025,6 +2025,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
           this.deletingRemoteMeta = true;
 
           await this.deleteRemoteMetadata();
+
           await uploadExtraMeta(this.getClient(),
             this.app.vault,
             undefined,
@@ -2041,9 +2042,9 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
   }
 
   private async deleteRemoteMetadata() {
-    let client = this.getClient();
-    let remoteFiles = await client.listFromRemote();
-    let remoteMetadata = await getRemoteMetadata(remoteFiles.Contents, client, this.plugin.settings.password)
+    const client = this.getClient();
+    const remoteFiles = await client.listFromRemote();
+    const remoteMetadata = await getRemoteMetadata(remoteFiles.Contents, client, this.plugin.settings.password)
 
     await client.deleteFromRemote(DEFAULT_FILE_NAME_FOR_METADATAONREMOTE, this.plugin.settings.password, remoteMetadata.remoteEncryptedKey);
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -55,7 +55,7 @@ import {
 } from "./moreOnLog";
 import {encryptStringToBase64url} from "./encrypt";
 import {DEFAULT_FILE_NAME_FOR_METADATAONREMOTE, DEFAULT_FILE_NAME_FOR_METADATAONREMOTE2} from "./metadataOnRemote";
-import {getMetadataFiles, uploadExtraMeta} from "./sync";
+import {getRemoteMetadata, uploadExtraMeta} from "./sync";
 
 class PasswordModal extends Modal {
   plugin: RemotelySavePlugin;
@@ -2043,13 +2043,9 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
   private async deleteRemoteMetadata() {
     let client = this.getClient();
     let remoteFiles = await client.listFromRemote();
-    let remoteMetadataFiles = await getMetadataFiles(remoteFiles.Contents, this.plugin.settings.password)
+    let remoteMetadata = await getRemoteMetadata(remoteFiles.Contents, client, this.plugin.settings.password)
 
-    for (const metadataFile of remoteMetadataFiles) {
-      await client.deleteFromRemote(DEFAULT_FILE_NAME_FOR_METADATAONREMOTE,
-        this.plugin.settings.password,
-        metadataFile);
-    }
+    await client.deleteFromRemote(DEFAULT_FILE_NAME_FOR_METADATAONREMOTE, this.plugin.settings.password, remoteMetadata.remoteEncryptedKey);
   }
 
   private getClient() {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -159,7 +159,7 @@ export const getRemoteMetadata = async (
     
     metadataFiles.forEach(async (file, index) => {
       if (index !== 0) {
-        await client.deleteFromRemote(DEFAULT_FILE_NAME_FOR_METADATAONREMOTE, password, file.key);
+        await client.deleteFromRemote(DEFAULT_FILE_NAME_FOR_METADATAONREMOTE, password, file.remoteEncryptedKey);
       }
     });
   }


### PR DESCRIPTION
Should fix #134 and #131.

I couldn't recreate there being multiple metadata files, but I know I have experienced having multiple before and it causing the sync status to show the older metadata last modified.

This PR should fix it. I split up `parseRemoteStates()` so that getting the metadata file can be consistent through the whole plugin. I also added a check for multiple metadata files and deletes them leaving the newest.